### PR TITLE
Option to only wait for services in specified compose files

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,11 @@ Help output:
 ```bash
 $ ./docker-stack-wait.sh -h
 docker-stack-wait.sh [opts] stack_name
-  -h:     this help message
-  -r:     treat a rollback as successful (by default, a rollback indicates failure)
-  -s sec: frequency to poll service state (default 5 sec)
-  -t sec: timeout to stop waiting
+  -h:         this help message
+  -r:         treat a rollback as successful (by default, a rollback indicates failure)
+  -s sec:     frequency to poll service state (default 5 sec)
+  -t sec:     overall timeout to stop waiting
+  -c compose: limit polling to services in a specified compose file
 ```
 
 ## Usage as container

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ docker-stack-wait.sh [opts] stack_name
   -r:         treat a rollback as successful (by default, a rollback indicates failure)
   -s sec:     frequency to poll service state (default 5 sec)
   -t sec:     overall timeout to stop waiting
-  -c compose: limit polling to services in a specified compose file
+  -c compose: limit polling to services defined in a compose file; may be specified multiple times
 ```
 
 ## Usage as container


### PR DESCRIPTION
Hi, this script of yours is a lifesaver. I've made the following enhancement for my organization, and it may be worth integrating upstream.

The `docker stack deploy` command allows for the deployment of services defined across multiple compose files, in the form `docker stack deploy -c docker-compose-1.yml -c docker-compose-2.yml -c docker-compose-3.yml STACKNAME`. In this scenario each compose file contains a subset of services comprising the whole stack.

This PR replicates this functionality, allowing users to optionally specify one or more compose files in the form `./docker-stack-wait.sh -c docker-compose-1.yml -c docker-compose-2.yml -c ... STACKNAME`, which then polls docker for the upgrade status of only those services defined in the specified compose files. In very large stacks, this helps reduce excessive queries to the Docker API as well as speeds up execution by not requiring the initial checks against untargeted services.

If the `-c` option is not specified, the default behavior of checking all services in the stack is used.

Any feedback is appreciated, and thanks.