### PR TITLE
Trim "max replica per node" text from service ls replicas output

### DIFF
--- a/docker-stack-wait.sh
+++ b/docker-stack-wait.sh
@@ -104,7 +104,7 @@ while [ "$stack_done" != "1" ]; do
 
     # identify/report current state
     if [ "$service_done" != "2" ]; then
-      replicas=$(docker service ls --format '{{.Replicas}}' --filter "id=$service_id")
+      replicas=$(docker service ls --format '{{.Replicas}}' --filter "id=$service_id" | cut -d' ' -f1)
       current=$(echo "$replicas" | cut -d/ -f1)
       target=$(echo "$replicas" | cut -d/ -f2)
       if [ "$current" != "$target" ]; then


### PR DESCRIPTION
When using [the "max replicas per node" feature](https://docs.docker.com/engine/reference/commandline/service_create/#specify-maximum-replicas-per-node---replicas-max-per-node#specify-maximum-replicas-per-node---replicas-max-per-node#specify-maximum-replicas-per-node---replicas-max-per-node) of `docker service create/update` and Compose version 3.8, replica count polling breaks due to extra output in the service config query:

```bash
~$ docker service ls --format '{{.Replicas}}' --filter "id=ydwpx4wbleas"
1/1 (max 1 per node)

~$ docker service ls --format '{{.Replicas}}' --filter "id=ydwpx4wbleas" | cut -d' ' -f1
1/1
```

This PR trims off the "max N per node" text.