### PR TITLE
no need for interactive terminal in the example docker run

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ docker-stack-wait.sh [opts] stack_name
 ## Usage as container
 
 ```bash
-$ docker run --rm -it \
+$ docker run --rm \
   -v /var/run/docker.sock:/var/run/docker.sock \
   sudobmitch/docker-stack-wait $stack_name
 ```


### PR DESCRIPTION
The example uses `-it` but it doesn't need to. It caused me problems in a CI/CD context. It only took 10 seconds to solve but it's unnecessary to begin with.