### PR TITLE
Add verbose option to show service logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,18 @@ $ alias docker-stack-wait='docker run --rm -it \
   sudobmitch/docker-stack-wait'
 ```
 
+## Development
+
+To test changes to the script easily, you can use the example `example-docker-compose.yml` file with:
+
+```bash
+docker-compose -f dind-docker-compose.yml up
+docker-compose -f dind-docker-compose.yml exec dind sh
+docker node ls || docker swarm init
+docker stack deploy --compose-file work/example-docker-compose.yml the_stack
+./work/docker-stack-wait.sh the_stack
+```
+
 ## Filter Examples
 
 The `-n` and `-f` options allow to select a subset of the services in a stack.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ docker-stack-wait.sh [opts] stack_name
   -h:        this help message
   -n name:   only wait for specific service names, overrides any filters,
              may be passed multiple times, do not include the stack name prefix
+  -p lines:  print last n lines of relevant service logs at end
+             passed to the '--tail' option of docker service logs
   -r:        treat a rollback as successful
   -s sec:    frequency to poll service state (default 5 sec)
   -t sec:    timeout to stop waiting

--- a/dind-docker-compose.yml
+++ b/dind-docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.9"
+services:
+  dind:
+    image: docker:dind
+    container_name: dind
+    privileged: true
+    volumes:
+      - .:/work
+    expose:
+      - 2375
+    environment:
+      - DOCKER_TLS_CERTDIR=
+

--- a/example-docker-compose.yml
+++ b/example-docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3.9"
+services:
+  img1:
+    image: alpine
+    command: sh -c "echo img1 && tail -f /dev/null"
+  img2:
+    image: alpine
+    command: sh -c "echo img2 && tail -f /dev/null"
+  img3:
+    image: alpine
+    command: sh -c "echo img3 starting && sleep 1 && echo img3 started && tail -f /dev/null"


### PR DESCRIPTION
Hi there :wave: 

We use docker-stack-wait during deployment of various projects at work and are quite happy with it :+1: 

However, when something goes wrong during deployment, e.g. if a container can't start properly, we don't have enough information about what went wrong.

To make debugging easier, I added a new -v (verbose) switch to display container logs of each service we're waiting on.

I tested my changes on one of our projects via [this newly pushed docker image](https://hub.docker.com/r/zinggi57/docker-stack-wait/tags)

Sample output from our CI with the new -v flag:

```
Service service_postgres state: deployed
service_mailhog.1.d4hp33ufd33o@service-staging    | [APIv1] KEEPALIVE /api/v1/events
Service service_mailhog state: deployed
Service service_caddy state: deployed
service_rails_app.1.nwv7ifk0jc7p@service-staging    | I, [2022-05-12T16:14:20.293030 #27]  INFO -- : [e2a12d6f-32d6-4d17-b606-f815a6d84de3] Started GET "/" for 127.0.0.1 at 2022-05-12 16:14:20 +0200
service_rails_app.1.nwv7ifk0jc7p@service-staging    | I, [2022-05-12T16:14:20.293969 #27]  INFO -- : [e2a12d6f-32d6-4d17-b606-f815a6d84de3] Processing by WelcomeController#index as */*
...
Service service_rails_app state: deployed
```

---

I also found it hard to test my changes locally, so I added this development section to the readme + the docker-compose files.

If you don't want to add that to the readme, or would like to have these changes in a separate PR, I can drop the commit and if desired create another PR just for those changes.