### PR TITLE
Chore: Bump GHA versions and archive project

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,8 +7,8 @@ on:
       - 'feature/**'
     tags:
       - 'v*.*.*'
-  schedule:
-    - cron: '0 06 * * 1'
+  # schedule:
+  #   - cron: '0 06 * * 1'
 
 jobs:
 
@@ -40,50 +40,40 @@ jobs:
           MAJOR=${MINOR%.*}
           TAGS="${TAGS},${HUB_IMAGE}:${MINOR},${HUB_IMAGE}:${MAJOR},${HUB_IMAGE}:latest,${GHCR_IMAGE}:${MINOR},${GHCR_IMAGE}:${MAJOR},${GHCR_IMAGE}:latest"
         fi
-        echo ::set-output name=version::${VERSION}
-        echo ::set-output name=tags::${TAGS}
-        echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+        VCS_DATE="$(date -d "@${VCS_SEC}" +%Y-%m-%dT%H:%M:%SZ --utc)"
+        echo "version=${VERSION}" >>$GITHUB_OUTPUT
+        echo "tags=${TAGS}" >>$GITHUB_OUTPUT
+        echo "created=${VCS_DATE}" >>$GITHUB_OUTPUT
 
     - name: Check out code
-      uses: actions/checkout@v2
-
-    # - name: Set up QEMU
-    #   uses: docker/setup-qemu-action@v1
+      uses: actions/checkout@v4
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v3
      
     - name: Login to DockerHub
       if: github.repository_owner == 'sudo-bmitch'
-      uses: docker/login-action@v1 
+      uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - name: Login to GHCR
       if: github.repository_owner == 'sudo-bmitch'
-      uses: docker/login-action@v1 
+      uses: docker/login-action@v3
       with:
         registry: ghcr.io
         username: ${{ secrets.GHCR_USERNAME }}
         password: ${{ secrets.GHCR_TOKEN }}
 
-    - name: Cache docker build
-      uses: actions/cache@v2
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx
-
     - name: Build and push 
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v6
       with:
         context: .
         file: ./Dockerfile
         platforms: linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
         push: ${{ github.event_name != 'pull_request' && github.repository_owner == 'sudo-bmitch' }}
         tags: ${{ steps.prep.outputs.tags }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache
         labels: |
           org.opencontainers.image.created=${{ steps.prep.outputs.created }}
           org.opencontainers.image.source=${{ github.repositoryUrl }}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 Waits for a docker stack deploy to complete.
 
+## Archive Notice
+
+This project has been archived and is no longer being maintained.
+Docker has added the `--detach` CLI flag which allows similar functionality to be implemented with:
+
+```shell
+docker stack deploy --detach=false -c docker-compose.yaml $stack_name
+```
+
+## CLI Usage
+
 Example Usage:
 
 `docker-stack-wait.sh $stack_name`


### PR DESCRIPTION
This project is no longer needed now that docker has:

```shell
docker stack deploy --detach=false ...
```
